### PR TITLE
Update Privacy Policy

### DIFF
--- a/docs/_pages/92_privacy-policy.md
+++ b/docs/_pages/92_privacy-policy.md
@@ -1,7 +1,7 @@
 ---
 permalink: /privacy-policy/
-title: "Privacy Policy"
-last_modified_at: 2021-02-27T00:00:00+09:00
+title: 'Privacy Policy'
+last_modified_at: 2023-03-25T02:00:00+09:00
 toc: true
 ---
 
@@ -10,13 +10,16 @@ Your privacy is extremely important to Me. This Privacy Policy outlines the type
 First and foremost, I will never share Your email address or any other personal information to anyone without Your direct consent.
 
 ## Definitions
+
 - **I** and **Me** refers to [Taro TSUKAGOSHI](https://github.com/ttsukagoshi), the sole administrator of this Website.
 - **Website** refers to this website at [https://www.scriptable-assets.page/](https://www.scriptable-assets.page/).
 - **Services** refers collectively to this Website and the apps, extensions, add-ons, and other types of solutions guided explicitly in this Website, to which I have the right to distribute.
 - **You** and **Your** refers to the users or viewers of the Services.
 
 ## Log Files
+
 Like many other websites, this Website uses log files to help learn about when, from where, and how often traffic flows to this Website. The information in these log files include:
+
 - Internet Protocol (IP) addresses
 - Types of browser
 - Internet Service Provider (ISP)
@@ -27,17 +30,28 @@ Like many other websites, this Website uses log files to help learn about when, 
 All of this information is not linked to anything that is personally identifiable.
 
 ## Cookies and Web Beacons
+
 If You wish to disable cookies, You may do so through Your web browser options. Instructions for doing so can be found on the specific web browsers' websites.
 
 ### Google Analytics
+
 Google Analytics is a web analytics tool I use to help understand how visitors engage with this Website. It reports website trends using cookies and web beacons without identifying individual visitors. I also use it in counting the installations of the Services that are hosted in the Chrome Web Store and Google Workspace Marketplace. You can read how Google uses data when You use sites or apps that use Google Analytics at [HOW GOOGLE USES INFORMATION FROM SITES OR APPS THAT USE OUR SERVICES](https://policies.google.com/technologies/partner-sites).
 
+## Adherence to External Policies
+
+### Google API Services User Data Policy
+
+Whenever applicable, the Services' use and transfer to any other app of information received from Google APIs will adhere to [Google API Services User Data Policy](https://developers.google.com/terms/api-services-user-data-policy#additional_requirements_for_specific_api_scopes), including the Limited Use requirements.
+
 ## Contact Information
+
 In any case that You [contact Me](#contact), I will use Your email address and other personal information for the sole purpose of replying to You on the subject of the contact, and nothing else. I will not share Your information with anyone else.  
-All contents of the correspondence, including email contents from You and My replies to them, will be archived for an indefinite time by default. If You wish them to be deleted, You can [contact Me](#contact) stating which correspondence you want deleted. 
+All contents of the correspondence, including email contents from You and My replies to them, will be archived for an indefinite time by default. If You wish them to be deleted, You can [contact Me](#contact) stating which correspondence you want deleted.
 
 ## Contact
+
 If You have any questions regarding this Privacy Policy, feel free to [contact Me](https://www.scriptable-assets.page/terms-and-conditions/#contact).
 
 ## History
+
 Changes made to this Privacy Policy are [recorded on the GitHub](https://github.com/ttsukagoshi/ttsukagoshi.github.io/commits/release/docs/_pages/92_privacy-policy.md).

--- a/docs/_pages/add-ons/add-ons_sheetsl.md
+++ b/docs/_pages/add-ons/add-ons_sheetsl.md
@@ -1,8 +1,8 @@
 ---
 permalink: /add-ons/sheetsl/
 title: 'SheetsL: DeepL Translation for Google Sheets&trade;'
-excerpt: Open-sourced Google Sheets addon to use DeepL translation. Translate the contents of the selected range and paste them in the range of cells adjacent to the original range.
-last_modified_at: 2023-03-20T02:00:00+09:00
+excerpt: Open-sourced Google Sheets add-on to use DeepL translation. Translate the contents of the selected range and paste them in the range of cells adjacent to the original range.
+last_modified_at: 2023-03-25T02:00:00+09:00
 toc: true
 published: true
 ---
@@ -15,7 +15,7 @@ English/[日本語]({{ site.url }}{{ site.baseurl }}/ja/add-ons/sheetsl/)
 [![CodeQL](https://github.com/ttsukagoshi/mail-merge-for-gmail/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/ttsukagoshi/mail-merge-for-gmail/actions/workflows/codeql-analysis.yml) [![Deploy](https://github.com/ttsukagoshi/mail-merge-for-gmail/actions/workflows/deploy.yml/badge.svg)](https://github.com/ttsukagoshi/mail-merge-for-gmail/actions/workflows/deploy.yml) [![Labeler](https://github.com/ttsukagoshi/mail-merge-for-gmail/actions/workflows/label.yml/badge.svg)](https://github.com/ttsukagoshi/mail-merge-for-gmail/actions/workflows/label.yml) [![Lint Code Base](https://github.com/ttsukagoshi/mail-merge-for-gmail/actions/workflows/linter.yml/badge.svg)](https://github.com/ttsukagoshi/mail-merge-for-gmail/actions/workflows/linter.yml)
 -->
 
-Open-sourced Google Sheets&trade; addon to use DeepL translation. Translate the contents of the selected range and paste them in the range of cells adjacent to the original range.
+Open-sourced Google Sheets&trade; add-on to use DeepL translation. Translate the contents of the selected range and paste them in the range of cells adjacent to the original range.
 
 ![SheetsL icon]({{ site.url }}{{ site.baseurl }}/assets/images/sheetsl/SheetsL_Application Card Banner_220.png)
 
@@ -85,10 +85,6 @@ This section constitutes an addition to the [Terms and Conditions]({{ site.url }
 {: .notice--info}
 
 **SheetsL: DeepL Translation for Google Sheets&trade;**, hereinafter referred to as the Add-on in this section, is in compliance with the [Privacy Policy]({{ site.url }}{{ site.baseurl }}/privacy-policy/) with regard to the processing of your private data, which includes the contents of your Google Sheets files and the authentication information for your DeepL API account. Please note that the handling of your data by the DeepL API is outside the scope of this policy; please be sure to understand their privacy policy as well when creating your DeepL API account.
-
-**Disclosure**  
-The Add-on's use and transfer to any other app of information received from Google APIs will adhere to [Google API Services User Data Policy](https://developers.google.com/terms/api-services-user-data-policy#additional_requirements_for_specific_api_scopes), including the Limited Use requirements.
-{: .notice--warning}
 
 Separate from these policies, Google provides protection for the add-on users' privacy by limiting the _scope_ of authorized information that an add-on can have access to, called the [Google OAuth Scopes](https://developers.google.com/identity/protocols/oauth2/scopes). The list of OAuth Scopes that this Add-on requests from the user is as follows. As you may notice, Google does not define an authorization scope that is completely fit to the purpose and required functions of this Add-on in their [Google Sheets](https://developers.google.com/sheets/api/guides/authorizing#OAuth2Authorizing) authorization scopes, so some of the scopes may seem broader than necessary. As a supplement to the Terms and Conditions, this is a legally binding statement that this Add-on will not process any authorized data in the manner not described in the below table:
 

--- a/docs/_pages/ja/add-ons_sheetsl.md
+++ b/docs/_pages/ja/add-ons_sheetsl.md
@@ -2,7 +2,7 @@
 permalink: /ja/add-ons/sheetsl/
 title: 'SheetsL: Googleスプレッドシート&trade;のためのDeepL翻訳'
 excerpt: DeepL翻訳を直接利用するための、オープンソースのGoogleスプレッドシートアドオン。選択したセル範囲の内容をDeepL APIで翻訳して、その結果を、選択したセル範囲の右隣に表示する。
-last_modified_at: 2023-03-13T02:00:00+09:00
+last_modified_at: 2023-03-25T02:00:00+09:00
 toc: true
 published: true
 ---


### PR DESCRIPTION
- Add the `Adherence to External Policies` section to Privacy Policy to meet the requirements in the verification of Google OAuth Scopes
- Delete the following phrase from the `Terms and Conditions` section of the SheetsL page as it will be redundant with the updated Privacy Policy:

> **Disclosure** The Add-on’s use and transfer to any other app of information received from Google APIs will adhere to [Google API Services User Data Policy](https://developers.google.com/terms/api-services-user-data-policy#additional_requirements_for_specific_api_scopes), including the Limited Use requirements.